### PR TITLE
use drawer dimensions for assertion

### DIFF
--- a/gridfinity-rebuilt-baseplate.scad
+++ b/gridfinity-rebuilt-baseplate.scad
@@ -51,8 +51,8 @@ gridfinityBaseplate(gridx, gridy, length, distancex, distancey, style_plate, ena
 
 module gridfinityBaseplate(gridx, gridy, length, dix, diy, sp, sm, sh) {
     
-    assert(gridx > 0 || dx > 0, "Must have positive x grid amount!");
-    assert(gridy > 0 || dy > 0, "Must have positive y grid amount!");
+    assert(gridx > 0 || dix > 0, "Must have positive x grid amount!");
+    assert(gridy > 0 || diy > 0, "Must have positive y grid amount!");
     gx = gridx == 0 ? floor(dix/length) : gridx; 
     gy = gridy == 0 ? floor(diy/length) : gridy; 
     dx = max(gx*length-0.5, dix);


### PR DESCRIPTION
assertion previously used an uninitialized variable to assert either grid count or drawer size were specified. this change updates the assertion to use the drawer dimension parameters. now a baseplate can be created purely with draw dimensions and without grid counts